### PR TITLE
Add link to related ECSS standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PLUTO Syntax Highlighter
 
-This simple extension provides highlighting for PLUTO(Procedure Language for Users in Test and Operations)
+This simple extension provides highlighting for PLUTO (Procedure Language for Users in Test and Operations),
+as defined in [ECSS-E-ST-70-31C](https://ecss.nl/standard/ecss-e-st-70-31c-ground-systems-and-operations-monitoring-and-control-data-definition/).
 
 The highlighter follows the basic naming conventions so it should be compatible with most VS Themes
 


### PR DESCRIPTION
Since there are actually a couple of PLUTO languages out there, this pull request adds a link to the relevant ECSS standard to prevent major confusion.